### PR TITLE
making separate requests for each course

### DIFF
--- a/backend/docprocessing/urls.py
+++ b/backend/docprocessing/urls.py
@@ -25,7 +25,7 @@ urlpatterns = [
     path('courses/<int:page>/<int:pageSize>', views.courses_paginated),
     path('courses/templates/<str:course_code>/', views.course_templates),
     # path('courses/<str:course_code>', views.courses_by_course_code),
-    path('assessments/<int:pk>/', views.assessments),
+    path('assessments/<str:course_code>/', views.assessments),
     path('learning-outcomes/<str:course_code>/', views.learning_outcomes),
     path('template/<str:courseId>/<str:assessmentId>/<str:version>', views.template),
     path('new_version/<str:course_code>/<str:assessment_id>', views.new_version),

--- a/frontend/src/components/BrowseCourses.tsx
+++ b/frontend/src/components/BrowseCourses.tsx
@@ -31,7 +31,7 @@ const BrowseCourses: React.FC = () => {
       }
     };
     fetchData();
-  }, [currentPage, pageSize]);
+  }, []);
 
   useEffect(() => {
     setFilteredRows(allRows);
@@ -75,7 +75,7 @@ const BrowseCourses: React.FC = () => {
         <Spacer height={"16px"} />
         <CourseTable
           rows={visibleRows}
-          totalRows={totalRows}
+          totalRows={filteredRows.length}
           paginatedTableProps={paginatedTableProps}
         />
       </Box>

--- a/frontend/src/components/BrowseCourses.tsx
+++ b/frontend/src/components/BrowseCourses.tsx
@@ -23,11 +23,9 @@ const BrowseCourses: React.FC = () => {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const response = await axios.get(
-          `http://127.0.0.1:8000/courses/${currentPage}/${pageSize}`
-        );
-        setAllRows(response.data.courses);
-        setTotalRows(response.data.total_courses);
+        const response = await axios.get(`http://127.0.0.1:8000/courses/`);
+        setAllRows(response.data);
+        setTotalRows(response.data.length);
       } catch (error) {
         console.error("Error fetching data:", error);
       }
@@ -76,7 +74,7 @@ const BrowseCourses: React.FC = () => {
         />
         <Spacer height={"16px"} />
         <CourseTable
-          rows={allRows}
+          rows={visibleRows}
           totalRows={totalRows}
           paginatedTableProps={paginatedTableProps}
         />

--- a/frontend/src/components/CoursesTable/AssessmentDropdown.tsx
+++ b/frontend/src/components/CoursesTable/AssessmentDropdown.tsx
@@ -1,0 +1,46 @@
+import { AccordionDetails } from "@mui/material";
+import { useEffect, useState } from "react";
+import AssessmentRow from "./AssessmentRow";
+import { AssessmentPreview } from "../../types/assessments";
+import axios from "axios";
+
+interface AssessmentDropdownProps {
+  courseCode: string;
+}
+
+const AssessmentDropdown: React.FC<AssessmentDropdownProps> = ({
+  courseCode,
+}) => {
+  const [assessments, setAssessments] = useState<AssessmentPreview[]>();
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const response = await axios.get(
+          `http://127.0.0.1:8000/assessments/${courseCode}/`
+        );
+        console.log(response);
+        setAssessments(response.data);
+      } catch (error) {
+        console.error("Error fetching data:", error);
+      }
+    };
+    fetchData();
+  }, [courseCode]);
+
+  return (
+    <AccordionDetails>
+      {assessments?.map((assessment) => {
+        return (
+          <AssessmentRow
+            assessmentId={assessment.id}
+            courseId={courseCode}
+            {...assessment}
+          />
+        );
+      })}
+    </AccordionDetails>
+  );
+};
+
+export default AssessmentDropdown;

--- a/frontend/src/components/CoursesTable/AssessmentDropdown.tsx
+++ b/frontend/src/components/CoursesTable/AssessmentDropdown.tsx
@@ -19,7 +19,6 @@ const AssessmentDropdown: React.FC<AssessmentDropdownProps> = ({
         const response = await axios.get(
           `http://127.0.0.1:8000/assessments/${courseCode}/`
         );
-        console.log(response);
         setAssessments(response.data);
       } catch (error) {
         console.error("Error fetching data:", error);

--- a/frontend/src/components/CoursesTable/AssessmentRow.tsx
+++ b/frontend/src/components/CoursesTable/AssessmentRow.tsx
@@ -34,7 +34,7 @@ const AssessmentRow: React.FC<AssessmentRowProps> = ({
   };
 
   const [selectedVersion, setSelectedVersion] = useState(
-    versionToString(versions[versions.length - 1])
+    versionToString(versions && versions[versions.length - 1])
   );
 
   const handleChange = (event: SelectChangeEvent) => {
@@ -63,7 +63,7 @@ const AssessmentRow: React.FC<AssessmentRowProps> = ({
             label="Version"
             onChange={handleChange}
           >
-            {versions.map((version) => {
+            {versions?.map((version) => {
               return (
                 <MenuItem value={versionToString(version)}>
                   {versionToString(version)}

--- a/frontend/src/components/CoursesTable/AssessmentRow.tsx
+++ b/frontend/src/components/CoursesTable/AssessmentRow.tsx
@@ -54,38 +54,42 @@ const AssessmentRow: React.FC<AssessmentRowProps> = ({
     >
       <Typography sx={{ fontSize: "16px" }}>{activity}</Typography>
       <Box sx={{ display: "flex", columnGap: "24px" }}>
-        <FormControl sx={{ m: 1, minWidth: 120 }} size="small">
-          <InputLabel id="demo-simple-select-label">Version</InputLabel>
-          <Select
-            labelId="demo-simple-select-label"
-            id="demo-simple-select"
-            value={selectedVersion}
-            label="Version"
-            onChange={handleChange}
-          >
-            {versions?.map((version) => {
-              return (
-                <MenuItem value={versionToString(version)}>
-                  {versionToString(version)}
-                </MenuItem>
-              );
-            })}
-          </Select>
-        </FormControl>
-        <Button
-          sx={{
-            "&:hover": {
-              backgroundColor: "#C8102E4D",
-            },
-            color: colors.black,
-          }}
-          color="secondary"
-          onClick={() =>
-            generateWordDocument(courseId, assessmentId, selectedVersion)
-          }
-        >
-          Export
-        </Button>
+        {versions.length > 0 && (
+          <>
+            <FormControl sx={{ m: 1, minWidth: 120 }} size="small">
+              <InputLabel id="demo-simple-select-label">Version</InputLabel>
+              <Select
+                labelId="demo-simple-select-label"
+                id="demo-simple-select"
+                value={selectedVersion}
+                label="Version"
+                onChange={handleChange}
+              >
+                {versions?.map((version) => {
+                  return (
+                    <MenuItem value={versionToString(version)}>
+                      {versionToString(version)}
+                    </MenuItem>
+                  );
+                })}
+              </Select>
+            </FormControl>
+            <Button
+              sx={{
+                "&:hover": {
+                  backgroundColor: "#C8102E4D",
+                },
+                color: colors.black,
+              }}
+              color="secondary"
+              onClick={() =>
+                generateWordDocument(courseId, assessmentId, selectedVersion)
+              }
+            >
+              Export
+            </Button>
+          </>
+        )}
         <NewVersionB assessmentId={id} courseId={courseId} />
       </Box>
     </AccordionDetails>

--- a/frontend/src/components/CoursesTable/CourseTable.tsx
+++ b/frontend/src/components/CoursesTable/CourseTable.tsx
@@ -84,17 +84,6 @@ const CourseTable: React.FC<CourseTableProps> = ({
                         </Box>
                       </AccordionSummary>
                       <AssessmentDropdown courseCode={row.code} />
-                      {/* <AccordionDetails>
-                        {row.assessments?.map((assessment) => {
-                          return (
-                            <AssessmentRow
-                              assessmentId={assessment.id}
-                              courseId={row.code}
-                              {...assessment}
-                            />
-                          );
-                        })}
-                      </AccordionDetails> */}
                     </Accordion>
                   </TableCell>
                 </TableRow>

--- a/frontend/src/components/CoursesTable/CourseTable.tsx
+++ b/frontend/src/components/CoursesTable/CourseTable.tsx
@@ -18,6 +18,7 @@ import { CoursePreview } from "../../types/courses";
 import { PaginatedTableProps } from "../../hooks/usePagination";
 import AssessmentRow from "./AssessmentRow";
 import { colors } from "../../theme";
+import AssessmentDropdown from "./AssessmentDropdown";
 
 interface CourseTableProps {
   rows: CoursePreview[];
@@ -82,8 +83,9 @@ const CourseTable: React.FC<CourseTableProps> = ({
                           </Typography>
                         </Box>
                       </AccordionSummary>
-                      <AccordionDetails>
-                        {row.assessments.map((assessment) => {
+                      <AssessmentDropdown courseCode={row.code} />
+                      {/* <AccordionDetails>
+                        {row.assessments?.map((assessment) => {
                           return (
                             <AssessmentRow
                               assessmentId={assessment.id}
@@ -92,7 +94,7 @@ const CourseTable: React.FC<CourseTableProps> = ({
                             />
                           );
                         })}
-                      </AccordionDetails>
+                      </AccordionDetails> */}
                     </Accordion>
                   </TableCell>
                 </TableRow>

--- a/frontend/src/components/CoursesTable/CourseTable.tsx
+++ b/frontend/src/components/CoursesTable/CourseTable.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import {
   Accordion,
   AccordionDetails,
@@ -32,6 +32,10 @@ const CourseTable: React.FC<CourseTableProps> = ({
   paginatedTableProps,
 }) => {
   const [openRow, setOpenRow] = useState<number | undefined>(undefined);
+
+  useEffect(() => {
+    setOpenRow(undefined);
+  }, [paginatedTableProps.page]);
 
   const handleChange =
     (panelIndex: number) =>


### PR DESCRIPTION
Main /courses endpoint now returns all of the courses again, but without any information about the assignments
Takes a second but pretty will only need to be run once and we can add a loading state
Search is now working again because all of the titles and course codes are available

Now each row in the table makes a request to get the information for the assessments and template versions.
We will definitely need to add a loading state for this

I wasn't sure whether each row should make the assessments request or one request to get everything on a page, but went with the first one so the top rows would get filled in first